### PR TITLE
Handle inconsistent `LocationHierarchy` responses.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.smartregister</groupId>
     <artifactId>fhir-common-utils</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <distributionManagement>
         <repository>

--- a/src/main/java/org/smartregister/model/location/LocationHierarchyTree.java
+++ b/src/main/java/org/smartregister/model/location/LocationHierarchyTree.java
@@ -23,8 +23,10 @@ import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.r4.model.Location;
 import org.hl7.fhir.r4.model.StringType;
 import org.hl7.fhir.r4.model.Type;
+import org.smartregister.utils.Constants;
 
 import java.util.List;
+import java.util.StringTokenizer;
 
 @DatatypeDef(name = "LocationHierarchyTree")
 public class LocationHierarchyTree extends Type implements ICompositeType {
@@ -37,7 +39,8 @@ public class LocationHierarchyTree extends Type implements ICompositeType {
 
     public void addLocation(Location location) {
         StringType idString = new StringType();
-        idString.setValue(location.getId());
+        String locationId = extractLocationId(location);
+        idString.setValue(locationId);
         if (location.getPartOf() == null || StringUtils.isEmpty(location.getPartOf().getReference())) {
             locationsHierarchy.addNode(idString.getValue(), location.getName(), location, null);
         } else {
@@ -47,6 +50,18 @@ public class LocationHierarchyTree extends Type implements ICompositeType {
             locationsHierarchy.addNode(
                     idString.getValue(), location.getName(), location, parentId.getValue());
         }
+    }
+
+    private static String extractLocationId(Location location) {
+        String locationId = location.getId();
+        StringTokenizer tokenizer = new StringTokenizer(locationId, Constants.FORWARD_SLASH);
+        while (tokenizer.hasMoreTokens()) {
+            String token = tokenizer.nextToken();
+            if (Constants.LOCATION.equals(token) && tokenizer.hasMoreTokens()) {
+                return token + Constants.FORWARD_SLASH + tokenizer.nextToken();
+            }
+        }
+        return locationId;
     }
 
     /**

--- a/src/test/java/org/smartregister/model/location/LocationHierarchyTreeTest.java
+++ b/src/test/java/org/smartregister/model/location/LocationHierarchyTreeTest.java
@@ -223,6 +223,27 @@ public class LocationHierarchyTreeTest {
                         .getValue());
     }
 
+    @Test
+    public void testAddLocationWithMalformedIdUsesCorrectId() {
+        Location location = new Location();
+        location.setId("http://test-server/fhir/Location/1/_history/3");
+        location.setName("Test Location");
+        Reference partOfReference = new Reference();
+        partOfReference.setReference("");
+        location.setPartOf(partOfReference);
+        LocationHierarchyTree locationHierarchyTree = new LocationHierarchyTree();
+        locationHierarchyTree.addLocation(location);
+
+        Tree tree = locationHierarchyTree.getLocationsHierarchy();
+        assertNotNull(tree);
+        assertNotNull(tree.getTree());
+        assertEquals("Location/1", tree.getTree().getTreeNodeId().getValue());
+        assertEquals("Location/1", tree.getTree().getTreeNode().getNodeId().getValue());
+        assertEquals("Test Location", tree.getTree().getTreeNode().getLabel().getValue());
+        assertNull(tree.getTree().getTreeNode().getParent().getValue());
+        assertEquals(0, tree.getTree().getTreeNode().getChildren().size());
+    }
+
     private static List<Location> getLocationList() {
         Location location1 = new Location();
         location1.setId("Location/1");


### PR DESCRIPTION
 Extract the location id in the correct format from the returned value when getId() is called
 fixes https://github.com/opensrp/fhir-common-utils/issues/17